### PR TITLE
Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,28 @@ module.exports = {
 };
 ````
 
+The up/down implementation can use either callback-style or return a Promise.
+
+````javascript
+'use strict';
+
+module.exports = {
+
+  up: function (db) {
+    return db.collection('albums').update({artist: 'The Beatles'}, {$set: {blacklisted: true}});
+  },
+
+  down: function (db) {
+    return db.collection('albums').update({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+  }
+};
+````
+
+Make sure the implementation matches the function signature.
+
+* `function up(db) { /* */ }` should return `Promise`
+* `function up(db, next) { /* */ }` should callback `next`
+
 ### Checking the status of the migrations
 At any time, you can check which migrations are applied (or not)
 

--- a/lib/actions/down.js
+++ b/lib/actions/down.js
@@ -3,6 +3,7 @@
 var async = require('async');
 var path = require('path');
 var _ = require('lodash');
+var shifting = require('shifting');
 
 var status = require('./status');
 var configFile = require('../env/configFile');
@@ -26,7 +27,7 @@ module.exports = function (db, done) {
       }
 
       var migration = migrationsDir.loadMigration(lastAppliedItem.fileName);
-      migration.down(db, function (err) {
+      shifting.call([migration, migration.down], db, function (err) {
         if (err) return next(new Error('Could not migrate down ' + lastAppliedItem.fileName + ': ' + err.message));
 
         var collectionName = configFile.read().changelogCollectionName;

--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -2,6 +2,7 @@
 
 var async = require('async');
 var status = require('./status');
+var shifting = require('shifting');
 var path = require('path');
 var _ = require('lodash');
 var moment = require('moment');
@@ -20,7 +21,7 @@ module.exports = function (db, done) {
       var pendingItems = _.filter(statusItems, {appliedAt: 'PENDING'});
       async.eachSeries(pendingItems, function (item, nextItem) {
         var migration = migrationsDir.loadMigration(item.fileName);
-        migration.up(db, function (err) {
+        shifting.call([migration, migration.up], db, function (err) {
           if (err) return nextItem(new Error('Could not migrate up ' + item.fileName + ': ' + err.message));
 
           var collectionName = configFile.read().changelogCollectionName;

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "async": "^1.5.2",
     "cli-table": "^0.3.1",
     "commander": "2.9.0",
+    "fs-extra": "^0.30.0",
     "lodash": "^4.13.1",
     "moment": "^2.13.0",
     "mongodb": "^2.1.21",
-    "fs-extra": "^0.30.0"
+    "shifting": "^1.1.1"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
Use [shifting](https://github.com/Moeriki/shifting) to allow up/down implementations to use either callback style or Promises.

````javascript
module.exports = {
  up: function (db) {
    return db.collection('albums')
      .update(
        {artist: 'The Beatles'},
        {$set: {blacklisted: true}}
      );
  },
  down: function (db) {
    return db.collection('albums')
      .update(
        {artist: 'The Beatles'},
        {$set: {blacklisted: false}}
    );
  },
};
````
