### PR TITLE
set default migrations dir if missing from config file

### DIFF
--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -11,6 +11,10 @@ function resolveMigrationsDirPath() {
   let migrationsDir;
   try {
     migrationsDir = configFile.read().migrationsDir;
+    // if config file doesn't have migrationsDir key, assume default 'migrations' dir
+    if (!migrationsDir) {
+        migrationsDir = DEFAULT_MIGRATIONS_DIR_NAME;
+    }
   } catch(err) {
     // config file could not be read, assume default 'migrations' dir
     migrationsDir = DEFAULT_MIGRATIONS_DIR_NAME;


### PR DESCRIPTION
Reading the config file was working, but if that config file didn't have the migrationsDir key it would fail. This fixes that issue.