### PR TITLE
Report errors when loading migration file fails

### DIFF
--- a/lib/actions/down.js
+++ b/lib/actions/down.js
@@ -12,8 +12,8 @@ module.exports = async db => {
   const lastAppliedItem = _.last(appliedItems);
 
   if (lastAppliedItem) {
-    const migration = migrationsDir.loadMigration(lastAppliedItem.fileName);
     try {
+      const migration = migrationsDir.loadMigration(lastAppliedItem.fileName);
       const args = fnArgs(migration.down);
       const down = args.length > 1 ? promisify(migration.down) : migration.down;
       await down(db);

--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -13,8 +13,8 @@ module.exports = async db => {
   const migrated = [];
 
   const migrateItem = async item => {
-    const migration = migrationsDir.loadMigration(item.fileName);
     try {
+      const migration = migrationsDir.loadMigration(item.fileName);
       const args = fnArgs(migration.up);
       const up = args.length > 1 ? promisify(migration.up) : migration.up;
       await up(db);


### PR DESCRIPTION
For example, I did something silly and used `await` at the top level:

```javascript
await Promise.resolve(true);

module.exports = {
  up(db) { /* .. */ },
  up(db) { /* .. */ },
};
```

This change catches the error and reports it as a failed migration.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes and has 100% coverage
