### PR TITLE
Better handling for configuration related errors

### DIFF
--- a/bin/migrate-mongo.js
+++ b/bin/migrate-mongo.js
@@ -6,7 +6,7 @@ const Table = require("cli-table");
 const migrateMongo = require("../lib/migrate-mongo");
 const pkgjson = require("../package.json");
 
-function printMigrated(migrated) {
+function printMigrated(migrated = []) {
   migrated.forEach(migratedItem => {
     console.log(`MIGRATED UP: ${migratedItem}`);
   });
@@ -69,8 +69,8 @@ program
         process.exit(0);
       })
       .catch(err => {
-        printMigrated(err.migrated);
         handleError(err);
+        printMigrated(err.migrated);
       });
   });
 


### PR DESCRIPTION
Fix for 
```
(node:14343) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'forEach' of undefined
    at printMigrated (~/node_modules/migrate-mongo/bin/migrate-mongo.js:10:12)
    at migrateMongo.database.connect.then.then.catch.err (~/node_modules/migrate-mongo/bin/migrate-mongo.js:74:9)
```

That was caused by errors like
> Error: config file does not exist
> MongoError: collection name must be a String
etc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
