### PR TITLE
Allow migrate-mongo-config to return static configuration object or a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,12 @@ Connect to a mongo database using the connection settings from the `migrate-mong
 const db = await database.connect();
 ```
 
-### `config.read() → JSON`
+### `config.read() → Promise<JSON>`
 
 Read connection settings from the `migrate-mongo-config.js` file.
 
 ```javascript
-const mongoConnectionSettings = config.read();
+const mongoConnectionSettings = await config.read();
 ```
 
 ### `up(MongoDb) → Promise<Array<fileName>>`

--- a/bin/migrate-mongo.js
+++ b/bin/migrate-mongo.js
@@ -47,10 +47,10 @@ program
     global.options = options;
     migrateMongo
       .create(description)
-      .then(fileName =>
-        console.log(
-          `Created: ${migrateMongo.config.read().migrationsDir}/${fileName}`
-        )
+      .then(fileName => 
+        migrateMongo.config.read().then(config => {
+          console.log(`Created: ${config.migrationsDir}/${fileName}`);
+        })
       )
       .catch(err => handleError(err));
   });

--- a/lib/actions/create.js
+++ b/lib/actions/create.js
@@ -12,7 +12,7 @@ module.exports = async description => {
   const filename = `${date.nowAsString()}-${description
     .split(" ")
     .join("_")}.js`;
-  const destination = path.join(migrationsDir.resolve(), filename);
+  const destination = path.join(await migrationsDir.resolve(), filename);
   await fs.copy(source, destination);
   return filename;
 };

--- a/lib/actions/down.js
+++ b/lib/actions/down.js
@@ -13,7 +13,7 @@ module.exports = async db => {
 
   if (lastAppliedItem) {
     try {
-      const migration = migrationsDir.loadMigration(lastAppliedItem.fileName);
+      const migration = await migrationsDir.loadMigration(lastAppliedItem.fileName);
       const args = fnArgs(migration.down);
       const down = args.length > 1 ? promisify(migration.down) : migration.down;
       await down(db);
@@ -22,8 +22,8 @@ module.exports = async db => {
         `Could not migrate down ${lastAppliedItem.fileName}: ${err.message}`
       );
     }
-
-    const collectionName = configFile.read().changelogCollectionName;
+    const config = await configFile.read();
+    const collectionName = config.changelogCollectionName;
     const collection = db.collection(collectionName);
     try {
       await collection.deleteOne({ fileName: lastAppliedItem.fileName });

--- a/lib/actions/status.js
+++ b/lib/actions/status.js
@@ -7,7 +7,8 @@ module.exports = async db => {
   await configFile.shouldExist();
   const fileNames = await migrationsDir.getFileNames();
 
-  const collectionName = configFile.read().changelogCollectionName;
+  const config = await configFile.read();
+  const collectionName = config.changelogCollectionName;
   const collection = db.collection(collectionName);
   const changelog = await collection.find({}).toArray();
 

--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -14,7 +14,7 @@ module.exports = async db => {
 
   const migrateItem = async item => {
     try {
-      const migration = migrationsDir.loadMigration(item.fileName);
+      const migration = await migrationsDir.loadMigration(item.fileName);
       const args = fnArgs(migration.up);
       const up = args.length > 1 ? promisify(migration.up) : migration.up;
       await up(db);
@@ -26,7 +26,8 @@ module.exports = async db => {
       throw error;
     }
 
-    const collectionName = configFile.read().changelogCollectionName;
+    const config = await configFile.read();
+    const collectionName = config.changelogCollectionName;
     const collection = db.collection(collectionName);
 
     const { fileName } = item;

--- a/lib/env/configFile.js
+++ b/lib/env/configFile.js
@@ -45,7 +45,8 @@ module.exports = {
     return path.basename(getConfigPath());
   },
 
-  read() {
-    return require(getConfigPath()); // eslint-disable-line
+  async read() {
+    const configPath = getConfigPath();
+    return require(configPath); // eslint-disable-line
   }
 };

--- a/lib/env/configFile.js
+++ b/lib/env/configFile.js
@@ -47,6 +47,6 @@ module.exports = {
 
   async read() {
     const configPath = getConfigPath();
-    return require(configPath); // eslint-disable-line
+    return Promise.resolve(require(configPath)); // eslint-disable-line
   }
 };

--- a/lib/env/database.js
+++ b/lib/env/database.js
@@ -4,7 +4,7 @@ const configFile = require("./configFile");
 
 module.exports = {
   async connect() {
-    const config = configFile.read();
+    const config = await configFile.read();
     const url = _.get(config, "mongodb.url");
     const databaseName = _.get(config, "mongodb.databaseName");
     const options = _.get(config, "mongodb.options");

--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -4,10 +4,11 @@ const configFile = require("./configFile");
 
 const DEFAULT_MIGRATIONS_DIR_NAME = "migrations";
 
-function resolveMigrationsDirPath() {
+async function resolveMigrationsDirPath() {
   let migrationsDir;
   try {
-    migrationsDir = configFile.read().migrationsDir; // eslint-disable-line
+    const config = await configFile.read();
+    migrationsDir = config.migrationsDir; // eslint-disable-line
     // if config file doesn't have migrationsDir key, assume default 'migrations' dir
     if (!migrationsDir) {
       migrationsDir = DEFAULT_MIGRATIONS_DIR_NAME;
@@ -27,7 +28,7 @@ module.exports = {
   resolve: resolveMigrationsDirPath,
 
   async shouldExist() {
-    const migrationsDir = resolveMigrationsDirPath();
+    const migrationsDir = await resolveMigrationsDirPath();
     try {
       await fs.stat(migrationsDir);
     } catch (err) {
@@ -36,7 +37,7 @@ module.exports = {
   },
 
   async shouldNotExist() {
-    const migrationsDir = resolveMigrationsDirPath();
+    const migrationsDir = await resolveMigrationsDirPath();
     const error = new Error(
       `migrations directory already exists: ${migrationsDir}`
     );
@@ -52,12 +53,13 @@ module.exports = {
   },
 
   async getFileNames() {
-    const migrationsDir = resolveMigrationsDirPath();
+    const migrationsDir = await resolveMigrationsDirPath();
     const files = await fs.readdir(migrationsDir);
     return files.filter(file => path.extname(file) === ".js");
   },
 
-  loadMigration(fileName) {
-    return require(path.join(resolveMigrationsDirPath(), fileName)); // eslint-disable-line
+  async loadMigration(fileName) {
+    const migrationsDir = await resolveMigrationsDirPath();
+    return require(path.join(migrationsDir, fileName)); // eslint-disable-line
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "migrate-mongo",
-  "version": "4.1.2",
+  "name": "@unbill/migrate-mongo",
+  "version": "5.0.0",
   "description": "A database migration tool for MongoDB in Node",
   "main": "lib/migrate-mongo.js",
   "bin": {
@@ -11,7 +11,7 @@
     "test-coverage": "nyc --reporter=text-lcov mocha --recursive | coveralls",
     "lint": "eslint lib/ test/"
   },
-  "author": "Sebastian Van Sande",
+  "author": "Sebastian Van Sande, Q2 Biller Direct Team",
   "license": "MIT",
   "keywords": [
     "migrate mongo mongodb migrations database"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unbill/migrate-mongo",
-  "version": "5.0.0",
+  "version": "4.2.0",
   "description": "A database migration tool for MongoDB in Node",
   "main": "lib/migrate-mongo.js",
   "bin": {

--- a/samples/migrate-mongo-config.js
+++ b/samples/migrate-mongo-config.js
@@ -1,6 +1,6 @@
 // In this file you can configure migrate-mongo
 
-module.exports = {
+const config = {
   mongodb: {
     // TODO Change (or review) the url to your MongoDB:
     url: "mongodb://localhost:27017",
@@ -21,3 +21,5 @@ module.exports = {
   // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
   changelogCollectionName: "changelog"
 };
+
+module.exports = Promise.resolve(config);

--- a/samples/migrate-mongo-config.js
+++ b/samples/migrate-mongo-config.js
@@ -23,4 +23,4 @@ const config = {
 };
 
 //Return the config as a promise
-module.exports = Promise.resolve(config);
+module.exports = config;

--- a/samples/migrate-mongo-config.js
+++ b/samples/migrate-mongo-config.js
@@ -22,4 +22,5 @@ const config = {
   changelogCollectionName: "changelog"
 };
 
+//Return the config as a promise
 module.exports = Promise.resolve(config);

--- a/test/down.test.js
+++ b/test/down.test.js
@@ -36,7 +36,7 @@ describe("down", () => {
 
   function mockMigrationsDir() {
     return {
-      loadMigration: sinon.stub().returns(migration)
+      loadMigration: sinon.stub().returns(Promise.resolve(migration))
     };
   }
 

--- a/test/env/configFile.test.js
+++ b/test/env/configFile.test.js
@@ -70,39 +70,36 @@ describe("configFile", () => {
   });
 
   describe("read()", () => {
-    it("should attempt to read the config file", done => {
+    it("should attempt to read the config file", async () => {
       const configPath = path.join(process.cwd(), "migrate-mongo-config.js");
       try {
-        configFile.read();
+        await configFile.read();
         expect.fail("Error was not thrown");
       } catch (err) {
         expect(err.message).to.equal(`Cannot find module '${configPath}'`);
-        done();
       }
     });
 
-    it("should be possible to read a custom, absolute config file path", done => {
+    it("should be possible to read a custom, absolute config file path", async () => {
       global.options = { file: "/some/absoluete/path/to/a-config-file.js" };
       try {
-        configFile.read();
+        await configFile.read();
         expect.fail("Error was not thrown");
       } catch (err) {
         expect(err.message).to.equal(
           `Cannot find module '${global.options.file}'`
         );
-        done();
       }
     });
 
-    it("should be possible to read a custom, relative config file path", done => {
+    it("should be possible to read a custom, relative config file path", async () => {
       global.options = { file: "./a/relative/path/to/a-config-file.js" };
       const configPath = path.join(process.cwd(), global.options.file);
       try {
-        configFile.read();
+        await configFile.read();
         expect.fail("Error was not thrown");
       } catch (err) {
         expect(err.message).to.equal(`Cannot find module '${configPath}'`);
-        done();
       }
     });
   });

--- a/test/env/migrationsDir.test.js
+++ b/test/env/migrationsDir.test.js
@@ -34,34 +34,34 @@ describe("migrationsDir", () => {
   });
 
   describe("resolve()", () => {
-    it("should use the configured relative migrations dir when a config file is available", () => {
+    it("should use the configured relative migrations dir when a config file is available", async () => {
       configFile.read.returns({
         migrationsDir: "custom-migrations-dir"
       });
-      expect(migrationsDir.resolve()).to.equal(
+      expect(await migrationsDir.resolve()).to.equal(
         path.join(process.cwd(), "custom-migrations-dir")
       );
     });
 
-    it("should use the configured absolute migrations dir when a config file is available", () => {
+    it("should use the configured absolute migrations dir when a config file is available", async () => {
       configFile.read.returns({
         migrationsDir: "/absolute/path/to/my/custom-migrations-dir"
       });
-      expect(migrationsDir.resolve()).to.equal(
+      expect(await migrationsDir.resolve()).to.equal(
         "/absolute/path/to/my/custom-migrations-dir"
       );
     });
 
-    it("should use the default migrations directory when no migrationsDir is specified in the config file", () => {
+    it("should use the default migrations directory when no migrationsDir is specified in the config file", async () => {
       configFile.read.returns({});
-      expect(migrationsDir.resolve()).to.equal(
+      expect(await migrationsDir.resolve()).to.equal(
         path.join(process.cwd(), "migrations")
       );
     });
 
-    it("should use the default migrations directory when unable to read the config file", () => {
+    it("should use the default migrations directory when unable to read the config file", async () => {
       configFile.read.throws(new Error("Cannot read config file"));
-      expect(migrationsDir.resolve()).to.equal(
+      expect(await migrationsDir.resolve()).to.equal(
         path.join(process.cwd(), "migrations")
       );
     });
@@ -134,14 +134,14 @@ describe("migrationsDir", () => {
   });
 
   describe("loadMigration()", () => {
-    it("should attempt to load the fileName in the migrations directory", () => {
+    it("should attempt to load the fileName in the migrations directory", async () => {
       const pathToMigration = path.join(
         process.cwd(),
         "migrations",
         "someFile.js"
       );
       try {
-        migrationsDir.loadMigration("someFile.js");
+        await migrationsDir.loadMigration("someFile.js");
         expect.fail("Error was not thrown");
       } catch (err) {
         expect(err.message).to.equal(`Cannot find module '${pathToMigration}'`);

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -51,10 +51,10 @@ describe("up", () => {
     mock.loadMigration = sinon.stub();
     mock.loadMigration
       .withArgs("20160607173840-first_pending_migration.js")
-      .returns(firstPendingMigration);
+      .returns(Promise.resolve(firstPendingMigration));
     mock.loadMigration
       .withArgs("20160608060209-second_pending_migration.js")
-      .returns(secondPendingMigration);
+      .returns(Promise.resolve(secondPendingMigration));
     return mock;
   }
 


### PR DESCRIPTION
Update configFile.read() to return a promise.  This allows the config file to be provided via an asynchronous method, such as an http call.  Ex: I used aws-sdk to get my connection string.  If a static config is returned, it is turned into a promise in the read using Promise.resolve(config).

Updated downstream code from the read() to accept a promise.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
