### PR TITLE
Use migrations/sample-migration.js as sample content if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ module.exports = {
 };
 ````
 
+#### Overriding the sample migration
+To override the content of the sample migration that will be created by the `create` command, 
+create a file **`sample-migration.js`** in the migrations directory.
+
 ### Checking the status of the migrations
 At any time, you can check which migrations are applied (or not)
 

--- a/lib/actions/create.js
+++ b/lib/actions/create.js
@@ -11,12 +11,10 @@ module.exports = async description => {
   const migrationsDirPath = await migrationsDir.resolve();
 
   // Check if there is a 'sample-migration.js' file in migrations dir - if there is, use that
-  const migrationDirSample = path.join(migrationsDirPath, 'sample-migration.js');
   let source;
-  try {
-    await fs.access(migrationDirSample); // check if file exists
-    source = migrationDirSample;
-  } catch (e) {
+  if (await migrationsDir.doesSampleMigrationExist()) {
+    source = await migrationsDir.resolveSampleMigrationPath();
+  } else {
     source = path.join(__dirname, "../../samples/migration.js");
   }
 

--- a/lib/actions/create.js
+++ b/lib/actions/create.js
@@ -8,11 +8,22 @@ module.exports = async description => {
     throw new Error("Missing parameter: description");
   }
   await migrationsDir.shouldExist();
-  const source = path.join(__dirname, "../../samples/migration.js");
+  const migrationsDirPath = await migrationsDir.resolve();
+
+  // Check if there is a 'sample-migration.js' file in migrations dir - if there is, use that
+  const migrationDirSample = path.join(migrationsDirPath, 'sample-migration.js');
+  let source;
+  try {
+    await fs.access(migrationDirSample); // check if file exists
+    source = migrationDirSample;
+  } catch (e) {
+    source = path.join(__dirname, "../../samples/migration.js");
+  }
+
   const filename = `${date.nowAsString()}-${description
     .split(" ")
     .join("_")}.js`;
-  const destination = path.join(await migrationsDir.resolve(), filename);
+  const destination = path.join(migrationsDirPath, filename);
   await fs.copy(source, destination);
   return filename;
 };

--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -24,8 +24,14 @@ async function resolveMigrationsDirPath() {
   return path.join(process.cwd(), migrationsDir);
 }
 
+async function resolveSampleMigrationPath() {
+  const migrationsDir = await resolveMigrationsDirPath();
+  return path.join(migrationsDir, 'sample-migration.js');
+}
+
 module.exports = {
   resolve: resolveMigrationsDirPath,
+  resolveSampleMigrationPath,
 
   async shouldExist() {
     const migrationsDir = await resolveMigrationsDirPath();
@@ -61,5 +67,15 @@ module.exports = {
   async loadMigration(fileName) {
     const migrationsDir = await resolveMigrationsDirPath();
     return require(path.join(migrationsDir, fileName)); // eslint-disable-line
-  }
+  },
+
+  async doesSampleMigrationExist() {
+    const samplePath = await resolveSampleMigrationPath();
+    try {
+      await fs.stat(samplePath);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  },
 };

--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -61,7 +61,7 @@ module.exports = {
   async getFileNames() {
     const migrationsDir = await resolveMigrationsDirPath();
     const files = await fs.readdir(migrationsDir);
-    return files.filter(file => path.extname(file) === ".js");
+    return files.filter(file => path.extname(file) === ".js" && path.basename(file) !== 'sample-migration.js');
   },
 
   async loadMigration(fileName) {

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -12,7 +12,8 @@ describe("create", () => {
 
   function mockMigrationsDir() {
     return {
-      shouldExist: sinon.stub().returns(Promise.resolve())
+      shouldExist: sinon.stub().returns(Promise.resolve()),
+      doesSampleMigrationExist: sinon.stub().returns(Promise.resolve(false))
     };
   }
 
@@ -113,5 +114,23 @@ describe("create", () => {
     } catch (err) {
       expect(err.message).to.equal("Copy failed");
     }
+  });
+
+  it("should use the sample migration file if it exists", async () => {
+    const clock = sinon.useFakeTimers(
+        new Date("2016-06-09T08:07:00.077Z").getTime()
+    );
+    migrationsDir.doesSampleMigrationExist.returns(true);
+    const filename = await create("my_description");
+    expect(migrationsDir.doesSampleMigrationExist.called).to.equal(true);
+    expect(fs.copy.called).to.equal(true);
+    expect(fs.copy.getCall(0).args[0]).to.equal(
+        path.join(process.cwd(), "migrations", "sample-migration.js")
+    );
+    expect(fs.copy.getCall(0).args[1]).to.equal(
+        path.join(process.cwd(), "migrations", "20160609080700-my_description.js")
+    );
+    expect(filename).to.equal("20160609080700-my_description.js");
+    clock.restore();
   });
 });

--- a/test/env/migrationsDir.test.js
+++ b/test/env/migrationsDir.test.js
@@ -148,4 +148,18 @@ describe("migrationsDir", () => {
       }
     });
   });
+
+  describe("doesSampleMigrationExist()", () => {
+    it("should return true if sample migration exists", async () => {
+      fs.stat.returns(Promise.resolve());
+      const result = await migrationsDir.doesSampleMigrationExist();
+      expect(result).to.equal(true);
+    });
+
+    it("should return false if sample migration doesn't exists", async () => {
+      fs.stat.returns(Promise.reject(new Error("It does not exist")));
+      const result = await migrationsDir.doesSampleMigrationExist();
+      expect(result).to.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds an easy way to provide a sample migration that will be used when the `create` command is executed.

It checks if the file exists, and if it does - uses that: **`<migrations-dir>/sample-migration.js`**

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
