### PR TITLE
Make migration file extension configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ module.exports = {
   migrationsDir: "migrations",
 
   // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
-  changelogCollectionName: "changelog"
+  changelogCollectionName: "changelog",
+
+  // The file extension to create migrations and search for in migration dir 
+  migrationFileExtension: ".js"
 };
 ````
 

--- a/lib/actions/create.js
+++ b/lib/actions/create.js
@@ -9,6 +9,7 @@ module.exports = async description => {
   }
   await migrationsDir.shouldExist();
   const migrationsDirPath = await migrationsDir.resolve();
+  const migrationExtension = await migrationsDir.resolveMigrationFileExtension();
 
   // Check if there is a 'sample-migration.js' file in migrations dir - if there is, use that
   let source;
@@ -20,7 +21,7 @@ module.exports = async description => {
 
   const filename = `${date.nowAsString()}-${description
     .split(" ")
-    .join("_")}.js`;
+    .join("_")}${migrationExtension}`;
   const destination = path.join(migrationsDirPath, filename);
   await fs.copy(source, destination);
   return filename;

--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -3,6 +3,7 @@ const path = require("path");
 const configFile = require("./configFile");
 
 const DEFAULT_MIGRATIONS_DIR_NAME = "migrations";
+const DEFAULT_MIGRATION_EXT = ".js";
 
 async function resolveMigrationsDirPath() {
   let migrationsDir;
@@ -29,9 +30,27 @@ async function resolveSampleMigrationPath() {
   return path.join(migrationsDir, 'sample-migration.js');
 }
 
+async function resolveMigrationFileExtension() {
+  let migrationFileExtension;
+  try {
+    const config = await configFile.read();
+    migrationFileExtension = config.migrationFileExtension || DEFAULT_MIGRATION_EXT;
+  } catch (err) {
+    // config file could not be read, assume default extension
+    migrationFileExtension = DEFAULT_MIGRATION_EXT;
+  }
+  
+  if (migrationFileExtension && !migrationFileExtension.startsWith('.')) {
+    throw new Error('migrationFileExtension must start with dot');
+  }
+
+  return migrationFileExtension;
+}
+
 module.exports = {
   resolve: resolveMigrationsDirPath,
   resolveSampleMigrationPath,
+  resolveMigrationFileExtension,
 
   async shouldExist() {
     const migrationsDir = await resolveMigrationsDirPath();
@@ -60,8 +79,9 @@ module.exports = {
 
   async getFileNames() {
     const migrationsDir = await resolveMigrationsDirPath();
+    const migrationExt = await resolveMigrationFileExtension();
     const files = await fs.readdir(migrationsDir);
-    return files.filter(file => path.extname(file) === ".js" && path.basename(file) !== 'sample-migration.js');
+    return files.filter(file => path.extname(file) === migrationExt && path.basename(file) !== 'sample-migration.js');
   },
 
   async loadMigration(fileName) {

--- a/samples/migrate-mongo-config.js
+++ b/samples/migrate-mongo-config.js
@@ -20,7 +20,10 @@ const config = {
   migrationsDir: "migrations",
 
   // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
-  changelogCollectionName: "changelog"
+  changelogCollectionName: "changelog",
+
+  // The file extension to create migrations and search for in migration dir 
+  migrationFileExtension: ".js"
 };
 
 // Return the config as a promise

--- a/test/actions/create.test.js
+++ b/test/actions/create.test.js
@@ -13,13 +13,14 @@ describe("create", () => {
   function mockMigrationsDir() {
     return {
       shouldExist: sinon.stub().returns(Promise.resolve()),
+      resolveMigrationFileExtension: sinon.stub().returns('.js'),
       doesSampleMigrationExist: sinon.stub().returns(Promise.resolve(false))
     };
   }
 
   function mockConfigFile() {
     return {
-      shouldExist: sinon.stub().returns(Promise.resolve())
+      shouldExist: sinon.stub().returns(Promise.resolve()),
     };
   }
 
@@ -84,6 +85,23 @@ describe("create", () => {
       path.join(process.cwd(), "migrations", "20160609080700-my_description.js")
     );
     expect(filename).to.equal("20160609080700-my_description.js");
+    clock.restore();
+  });
+
+  it("should create a new migration file and yield the filename with custom extension", async () => {
+    const clock = sinon.useFakeTimers(
+      new Date("2016-06-09T08:07:00.077Z").getTime()
+    );
+    migrationsDir.resolveMigrationFileExtension.returns('.ts');
+    const filename = await create("my_description");
+    expect(fs.copy.called).to.equal(true);
+    expect(fs.copy.getCall(0).args[0]).to.equal(
+      path.join(__dirname, "../../samples/migration.js")
+    );
+    expect(fs.copy.getCall(0).args[1]).to.equal(
+      path.join(process.cwd(), "migrations", "20160609080700-my_description.ts")
+    );
+    expect(filename).to.equal("20160609080700-my_description.ts");
     clock.restore();
   });
 


### PR DESCRIPTION
I use typescript and can run `migrate-mongo` through `ts-node`, but the module file extension is hard-coded. This PR makes it a config option that defaults to `.js`. The config option is used when `create` is called and when getting migration directory listing.

##### Checklist
- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
