### PR TITLE
Feature/soft lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ module.exports = {
   // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determin
   // if the file should be run.  Requires that scripts are coded to be run multiple times.
   useFileHash: false
+
+  // The mongodb collection where the lock will be created.
+  lockCollectionName: "changelog_lock",
+
+  // The value in seconds for the TTL index that will be used for the lock. Value of 0 will disable the feature.
+  lockTtl: 0
 };
 ````
 

--- a/lib/actions/down.js
+++ b/lib/actions/down.js
@@ -1,17 +1,28 @@
 const _ = require("lodash");
 const { promisify } = require("util");
-const fnArgs = require('fn-args');
+const fnArgs = require("fn-args");
 
 const status = require("./status");
 const config = require("../env/config");
 const migrationsDir = require("../env/migrationsDir");
-const hasCallback = require('../utils/has-callback');
+const hasCallback = require("../utils/has-callback");
+const lock = require("../utils/lock");
 
 module.exports = async (db, client) => {
   const downgraded = [];
   const statusItems = await status(db);
   const appliedItems = statusItems.filter(item => item.appliedAt !== "PENDING");
   const lastAppliedItem = _.last(appliedItems);
+
+  if (await lock.exist(db)) {
+    throw new Error("Could not migrate down, a lock is in place.");
+  }
+
+  try {
+    await lock.activate(db);
+  } catch(err) {
+    throw new Error(`Could not create a lock: ${err.message}`);
+  }
 
   if (lastAppliedItem) {
     try {
@@ -26,6 +37,7 @@ module.exports = async (db, client) => {
       }
 
     } catch (err) {
+      await lock.clear(db);
       throw new Error(
         `Could not migrate down ${lastAppliedItem.fileName}: ${err.message}`
       );
@@ -40,5 +52,6 @@ module.exports = async (db, client) => {
     }
   }
 
+  await lock.clear(db);
   return downgraded;
 };

--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -1,17 +1,28 @@
 const _ = require("lodash");
 const pEachSeries = require("p-each-series");
 const { promisify } = require("util");
-const fnArgs = require('fn-args');
+const fnArgs = require("fn-args");
 
 const status = require("./status");
 const config = require("../env/config");
 const migrationsDir = require("../env/migrationsDir");
-const hasCallback = require('../utils/has-callback');
+const hasCallback = require("../utils/has-callback");
+const lock = require("../utils/lock");
 
 module.exports = async (db, client) => {
   const statusItems = await status(db);
   const pendingItems = _.filter(statusItems, { appliedAt: "PENDING" });
   const migrated = [];
+
+  if (await lock.exist(db)) {
+    throw new Error("Could not migrate up, a lock is in place.");
+  }
+
+  try {
+    await lock.activate(db);
+  } catch(err) {
+    throw new Error(`Could not create a lock: ${err.message}`);
+  }
 
   const migrateItem = async item => {
     try {
@@ -31,6 +42,7 @@ module.exports = async (db, client) => {
       );
       error.stack = err.stack;
       error.migrated = migrated;
+      await lock.clear(db);
       throw error;
     }
 
@@ -49,5 +61,6 @@ module.exports = async (db, client) => {
   };
 
   await pEachSeries(pendingItems, migrateItem);
+  await lock.clear(db);
   return migrated;
 };

--- a/lib/utils/lock.js
+++ b/lib/utils/lock.js
@@ -1,0 +1,42 @@
+const config = require('../env/config');
+
+async function getLockCollection(db) {
+    const { lockCollectionName, lockTtl } = await config.read();
+    if (lockTtl <= 0) {
+        return null;
+    }
+
+    const lockCollection = db.collection(lockCollectionName);
+    lockCollection.createIndex({ createdAt: 1 }, { expireAfterSeconds: lockTtl });
+    return lockCollection;
+}
+
+async function exist(db) {
+    const lockCollection = await getLockCollection(db);
+    if (!lockCollection) {
+        return false;
+    }
+    const foundLocks = await lockCollection.find({}).toArray();
+
+    return foundLocks.length > 0;
+}
+
+async function activate(db) {
+    const lockCollection = await getLockCollection(db);
+    if (lockCollection) {
+        await lockCollection.insertOne({ createdAt: new Date() });
+    }
+}
+
+async function clear(db) {
+    const lockCollection = await getLockCollection(db);
+    if (lockCollection) {
+        await lockCollection.deleteMany({});
+    }
+}
+
+module.exports = {
+    exist,
+    activate,
+    clear,
+}

--- a/samples/migrate-mongo-config.js
+++ b/samples/migrate-mongo-config.js
@@ -22,6 +22,12 @@ const config = {
   // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
   changelogCollectionName: "changelog",
 
+  // The mongodb collection where the lock will be created.
+  lockCollectionName: "changelog_lock",
+
+  // The value in seconds for the TTL index that will be used for the lock. Value of 0 will disable the feature.
+  lockTtl: 0,
+
   // The file extension to create migrations and search for in migration dir 
   migrationFileExtension: ".js",
 

--- a/test/actions/up.test.js
+++ b/test/actions/up.test.js
@@ -7,6 +7,7 @@ describe("up", () => {
   let up;
   let status;
   let config;
+  let lock;
   let migrationsDir;
   let db;
   let client;
@@ -14,6 +15,7 @@ describe("up", () => {
   let firstPendingMigration;
   let secondPendingMigration;
   let changelogCollection;
+  let changelogLockCollection;
 
   function mockStatus() {
     return sinon.stub().returns(
@@ -42,7 +44,9 @@ describe("up", () => {
     return {
       shouldExist: sinon.stub().returns(Promise.resolve()),
       read: sinon.stub().returns({
-        changelogCollectionName: "changelog"
+        changelogCollectionName: "changelog",
+        lockCollectionName: "changelog_lock",
+        lockTtl: 10
       })
     };
   }
@@ -63,6 +67,7 @@ describe("up", () => {
     const mock = {};
     mock.collection = sinon.stub();
     mock.collection.withArgs("changelog").returns(changelogCollection);
+    mock.collection.withArgs("changelog_lock").returns(changelogLockCollection);
     return mock;
   }
 
@@ -84,11 +89,33 @@ describe("up", () => {
     };
   }
 
+  function mockChangelogLockCollection() {
+    const findStub = {
+      toArray: () => {
+        return [];
+      }
+    }
+
+    return {
+      insertOne: sinon.stub().returns(Promise.resolve()),
+      createIndex: sinon.stub().returns(Promise.resolve()),
+      find: sinon.stub().returns(findStub),
+      deleteMany: sinon.stub().returns(Promise.resolve()),
+    }
+  }
+
   function loadUpWithInjectedMocks() {
     return proxyquire("../../lib/actions/up", {
       "./status": status,
       "../env/config": config,
-      "../env/migrationsDir": migrationsDir
+      "../env/migrationsDir": migrationsDir,
+      "../utils/lock": lock
+    });
+  }
+
+  function loadLockWithInjectedMocks() {
+    return proxyquire("../../lib/utils/lock", {
+      "../env/config": config
     });
   }
 
@@ -96,6 +123,7 @@ describe("up", () => {
     firstPendingMigration = mockMigration();
     secondPendingMigration = mockMigration();
     changelogCollection = mockChangelogCollection();
+    changelogLockCollection = mockChangelogLockCollection();
 
     status = mockStatus();
     config = mockConfig();
@@ -103,6 +131,7 @@ describe("up", () => {
     db = mockDb();
     client = mockClient();
 
+    lock = loadLockWithInjectedMocks();
     up = loadUpWithInjectedMocks();
   });
 
@@ -197,6 +226,65 @@ describe("up", () => {
     } catch (err) {
       expect(err.message).to.deep.equal(
         "Could not update changelog: Kernel panic"
+      );
+    }
+  });
+
+  it("should lock if feature is enabled", async() => {
+    await up(db);
+    expect(changelogLockCollection.createIndex.called).to.equal(true);
+    expect(changelogLockCollection.find.called).to.equal(true);
+    expect(changelogLockCollection.insertOne.called).to.equal(true);
+    expect(changelogLockCollection.deleteMany.called).to.equal(true);
+  });
+
+  it("should ignore lock if feature is disabled", async() => {
+    config.read = sinon.stub().returns({
+      changelogCollectionName: "changelog",
+      lockCollectionName: "changelog_lock",
+      lockTtl: 0
+    });
+    const findStub = {
+      toArray: () => {
+        return [{ createdAt: new Date() }];
+      }
+    }
+    changelogLockCollection.find.returns(findStub);
+
+    await up(db);
+    expect(changelogLockCollection.createIndex.called).to.equal(false);
+    expect(changelogLockCollection.find.called).to.equal(false);
+    expect(changelogLockCollection.insertOne.called).to.equal(false);
+    expect(changelogLockCollection.deleteMany.called).to.equal(false);
+  });
+
+  it("should yield an error when unable to create a lock", async() => {
+    changelogLockCollection.insertOne.returns(Promise.reject(new Error("Kernel panic")));
+
+    try {
+      await up(db);
+      expect.fail("Error was not thrown");
+    } catch (err) {
+      expect(err.message).to.deep.equal(
+        "Could not create a lock: Kernel panic"
+      );
+    }
+  });
+
+  it("should yield an error when changelog is locked", async() => {
+    const findStub = {
+      toArray: () => {
+        return [{ createdAt: new Date() }];
+      }
+    }
+    changelogLockCollection.find.returns(findStub);
+    
+    try {
+      await up(db);
+      expect.fail("Error was not thrown");
+    } catch (err) {
+      expect(err.message).to.deep.equal(
+        "Could not migrate up, a lock is in place."
       );
     }
   });


### PR DESCRIPTION
When automating the migration process this tool might really comes in handy and alleviate a lot of pain.
Especially in a micro-services architecture with a lot of environments.
Nevertheless, depending on the deployment process, one might have to trigger the automated migration just right before the start of the application.
And if there are multiple applications running in parallel, multiple deployment might occur in parallel. Thus, the risk of having migration running in parallel is real and can lead to a lot of drama.

So, in order to avoid that, I propose a little feature which I would call "soft lock" relying on the TTL indexes mongodb provides (https://docs.mongodb.com/manual/core/index-ttl/).

The idea is to have a collection which should contain maximum one document. A fetch on this collection is done at the start of a migration.
* If no document is found in this lock collection, the migration will start and add one document to the lock collection.
When the process finishes - or has failed - this document is removed.
* If a document is found in this lock collection at the start of the migration, the migration is then cancelled.
If anything goes wrong and the lock is not cleared, the TTL index will take care of it.

- [X] `npm test` passes and has 100% coverage
- [X] README.md is updated
