### PR TITLE
Sorting the migration files

### DIFF
--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -81,7 +81,7 @@ module.exports = {
     const migrationsDir = await resolveMigrationsDirPath();
     const migrationExt = await resolveMigrationFileExtension();
     const files = await fs.readdir(migrationsDir);
-    return files.filter(file => path.extname(file) === migrationExt && path.basename(file) !== 'sample-migration.js');
+    return files.filter(file => path.extname(file) === migrationExt && path.basename(file) !== 'sample-migration.js').sort();
   },
 
   async loadMigration(fileName) {

--- a/test/env/migrationsDir.test.js
+++ b/test/env/migrationsDir.test.js
@@ -135,6 +135,22 @@ describe("migrationsDir", () => {
         expect(err.message).to.equal("Could not read");
       }
     });
+
+    it("should be sorted in alphabetical order", async () => {
+      fs.readdir.returns(Promise.resolve([
+        "20201014172343-test.js",
+        "20201014172356-test3.js",
+        "20201014172354-test2.js",
+        "20201014172345-test1.js"
+      ]));
+      const files = await migrationsDir.getFileNames();
+      expect(files).to.deep.equal([
+        "20201014172343-test.js",
+        "20201014172345-test1.js",
+        "20201014172354-test2.js",
+        "20201014172356-test3.js"
+      ]);
+    });
   });
 
   describe("loadMigration()", () => {


### PR DESCRIPTION
**Description**
https://github.com/seppevs/migrate-mongo/issues/260

**Fix**
Sort after the filter in getFileNames() in migrationDir.js

- [X] `npm test` passes and has 100% coverage
- [X] README.md is updated
