### PR TITLE
Made migration sample file take custom file extension into account

### DIFF
--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -25,11 +25,6 @@ async function resolveMigrationsDirPath() {
   return path.join(process.cwd(), migrationsDir);
 }
 
-async function resolveSampleMigrationPath() {
-  const migrationsDir = await resolveMigrationsDirPath();
-  return path.join(migrationsDir, 'sample-migration.js');
-}
-
 async function resolveMigrationFileExtension() {
   let migrationFileExtension;
   try {
@@ -45,6 +40,17 @@ async function resolveMigrationFileExtension() {
   }
 
   return migrationFileExtension;
+}
+
+async function resolveSampleMigrationFileName() {
+  const migrationFileExtention = await resolveMigrationFileExtension();
+  return `sample-migration${migrationFileExtention}`;
+}
+
+async function resolveSampleMigrationPath() {
+  const migrationsDir = await resolveMigrationsDirPath();
+  const sampleMigrationSampleFileName = await resolveSampleMigrationFileName();
+  return path.join(migrationsDir, sampleMigrationSampleFileName);
 }
 
 module.exports = {
@@ -81,7 +87,8 @@ module.exports = {
     const migrationsDir = await resolveMigrationsDirPath();
     const migrationExt = await resolveMigrationFileExtension();
     const files = await fs.readdir(migrationsDir);
-    return files.filter(file => path.extname(file) === migrationExt && path.basename(file) !== 'sample-migration.js').sort();
+    const sampleMigrationFileName = await resolveSampleMigrationFileName();
+    return files.filter(file => path.extname(file) === migrationExt && path.basename(file) !== sampleMigrationFileName).sort();
   },
 
   async loadMigration(fileName) {


### PR DESCRIPTION
When specifying a different extension, the config did not take into account the migration extension for the sample file. 
This PR fixes that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes and has 100% coverage
- [X] README.md is updated
