### PR TITLE
Enable rollback of all scripts from same migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ $ migrate-mongo status
 └─────────────────────────────────────────┴────────────┘
 ````
 
+#### Migrate down all scripts from a same migration
+With the flag -b (--block), migrate-mongo will revert all scripts of the last migration.
+````bash
+$ migrate-mongo down -b
+````
+
 ## Advanced Features
 
 ### Using a custom config file

--- a/bin/migrate-mongo.js
+++ b/bin/migrate-mongo.js
@@ -20,7 +20,7 @@ function handleError(err) {
 function printStatusTable(statusItems) {
   return migrateMongo.config.read().then(config => {
     const useFileHash = config.useFileHash === true;
-    const table = new Table({ head: useFileHash ? ["Filename", "Hash", "Applied At"] : ["Filename", "Applied At"]});
+    const table = new Table({ head: useFileHash ? ["Filename", "Hash", "Applied At", "Migration block"] : ["Filename", "Applied At", "Migration block"]});
     statusItems.forEach(item => table.push(_.values(item)));
     console.log(table.toString());
   })
@@ -82,6 +82,7 @@ program
   .command("down")
   .description("undo the last applied database migration")
   .option("-f --file <file>", "use a custom config file")
+  .option("-b --block", "rollback all scripts from the same migration block")
   .action(options => {
     global.options = options;
     migrateMongo.database

--- a/lib/actions/down.js
+++ b/lib/actions/down.js
@@ -1,4 +1,5 @@
 const _ = require("lodash");
+const pEachSeries = require("p-each-series");
 const { promisify } = require("util");
 const fnArgs = require('fn-args');
 
@@ -8,37 +9,49 @@ const migrationsDir = require("../env/migrationsDir");
 const hasCallback = require('../utils/has-callback');
 
 module.exports = async (db, client) => {
+  const isBlockRollback = _.get(global.options, "block");
   const downgraded = [];
   const statusItems = await status(db);
   const appliedItems = statusItems.filter(item => item.appliedAt !== "PENDING");
   const lastAppliedItem = _.last(appliedItems);
+  
+  let itemsToRollback = [];
 
-  if (lastAppliedItem) {
-    try {
-      const migration = await migrationsDir.loadMigration(lastAppliedItem.fileName);
-      const down = hasCallback(migration.down) ? promisify(migration.down) : migration.down;
+  if (isBlockRollback && lastAppliedItem.migrationBlock) {
+    itemsToRollback = appliedItems.filter(item => item.migrationBlock === lastAppliedItem.migrationBlock).reverse();
+  } else {
+    itemsToRollback = [lastAppliedItem];
+  }
 
-      if (hasCallback(migration.down) && fnArgs(migration.down).length < 3) {
-        // support old callback-based migrations prior to migrate-mongo 7.x.x
-        await down(db);
-      } else {
-        await down(db, client);
+  const rollbackItem = async item => {
+    if (item) {
+      try {
+        const migration = await migrationsDir.loadMigration(item.fileName);
+        const down = hasCallback(migration.down) ? promisify(migration.down) : migration.down;
+  
+        if (hasCallback(migration.down) && fnArgs(migration.down).length < 3) {
+          // support old callback-based migrations prior to migrate-mongo 7.x.x
+          await down(db);
+        } else {
+          await down(db, client);
+        }
+  
+      } catch (err) {
+        throw new Error(
+          `Could not migrate down ${item.fileName}: ${err.message}`
+        );
       }
-
-    } catch (err) {
-      throw new Error(
-        `Could not migrate down ${lastAppliedItem.fileName}: ${err.message}`
-      );
-    }
-    const { changelogCollectionName } = await config.read();
-    const changelogCollection = db.collection(changelogCollectionName);
-    try {
-      await changelogCollection.deleteOne({ fileName: lastAppliedItem.fileName });
-      downgraded.push(lastAppliedItem.fileName);
-    } catch (err) {
-      throw new Error(`Could not update changelog: ${err.message}`);
+      const { changelogCollectionName } = await config.read();
+      const changelogCollection = db.collection(changelogCollectionName);
+      try {
+        await changelogCollection.deleteOne({ fileName: item.fileName });
+        downgraded.push(item.fileName);
+      } catch (err) {
+        throw new Error(`Could not update changelog: ${err.message}`);
+      }
     }
   }
 
+  await pEachSeries(itemsToRollback, rollbackItem);
   return downgraded;
 };

--- a/lib/actions/status.js
+++ b/lib/actions/status.js
@@ -22,7 +22,8 @@ module.exports = async db => {
     }
     const itemInLog = find(changelog, findTest);
     const appliedAt = itemInLog ? itemInLog.appliedAt.toJSON() : "PENDING";
-    return useFileHash ? { fileName, fileHash, appliedAt } : { fileName, appliedAt };
+    const migrationBlock = itemInLog ? itemInLog.migrationBlock : undefined;
+    return useFileHash ? { fileName, fileHash, appliedAt, migrationBlock } : { fileName, appliedAt, migrationBlock };
   }));
 
   return statusTable;

--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -12,6 +12,7 @@ module.exports = async (db, client) => {
   const statusItems = await status(db);
   const pendingItems = _.filter(statusItems, { appliedAt: "PENDING" });
   const migrated = [];
+  const migrationBlock = Date.now();
 
   const migrateItem = async item => {
     try {
@@ -41,7 +42,7 @@ module.exports = async (db, client) => {
     const appliedAt = new Date();
 
     try {
-      await changelogCollection.insertOne(useFileHash === true ? { fileName, fileHash, appliedAt } : { fileName, appliedAt });
+      await changelogCollection.insertOne(useFileHash === true ? { fileName, fileHash, appliedAt, migrationBlock } : { fileName, appliedAt, migrationBlock });
     } catch (err) {
       throw new Error(`Could not update changelog: ${err.message}`);
     }

--- a/test/actions/down.test.js
+++ b/test/actions/down.test.js
@@ -18,11 +18,17 @@ describe("down", () => {
       Promise.resolve([
         {
           fileName: "20160609113224-first_migration.js",
-          appliedAt: new Date()
+          appliedAt: new Date(),
+        },
+        {
+          fileName: "20160609113224-second_migration.js",
+          appliedAt: new Date(),
+          migrationBlock: 1
         },
         {
           fileName: "20160609113225-last_migration.js",
-          appliedAt: new Date()
+          appliedAt: new Date(),
+          migrationBlock: 1
         }
       ])
     );
@@ -178,5 +184,11 @@ describe("down", () => {
   it("should yield a list of downgraded items", async () => {
     const items = await down(db);
     expect(items).to.deep.equal(["20160609113225-last_migration.js"]);
+  });
+
+  it("should rollback last migrations scripts of a same migration block", async () => {
+    global.options = { block: true };
+    const items = await down(db);
+    expect(items).to.deep.equal(["20160609113225-last_migration.js", "20160609113224-second_migration.js"]);
   });
 });

--- a/test/actions/status.test.js
+++ b/test/actions/status.test.js
@@ -199,15 +199,18 @@ describe("status", () => {
     expect(statusItems).to.deep.equal([
       {
         appliedAt: "2016-06-03T20:10:12.123Z",
-        fileName: "20160509113224-first_migration.js"
+        fileName: "20160509113224-first_migration.js",
+        migrationBlock: undefined
       },
       {
         appliedAt: "2016-06-09T20:10:12.123Z",
-        fileName: "20160512091701-second_migration.js"
+        fileName: "20160512091701-second_migration.js",
+        migrationBlock: undefined
       },
       {
         appliedAt: "PENDING",
-        fileName: "20160513155321-third_migration.js"
+        fileName: "20160513155321-third_migration.js",
+        migrationBlock: undefined
       }
     ]);
   });
@@ -220,16 +223,19 @@ describe("status", () => {
         appliedAt: "PENDING",
         fileName: "20160509113224-first_migration.js",
         fileHash: "0f295f21f63c66dc78d8dc091ce3c8bab8c56d8b74fb35a0c99f6d9953e37d1a",
+        migrationBlock: undefined
       },
       {
         appliedAt: "PENDING",
         fileName: "20160512091701-second_migration.js",
         fileHash: "18b4d9c95a8678ae3a6dd3ae5b8961737a6c3dd65e3e655a5f5718d97a0bff70",
+        migrationBlock: undefined
       },
       {
         appliedAt: "PENDING",
         fileName: "20160513155321-third_migration.js",
         fileHash: "1f9eb3b5eb70b2fb5b83fa0c660d859082f0bb615e835d29943d26fb0d352022",
+        migrationBlock: undefined
       }
     ]);
   });
@@ -243,16 +249,19 @@ describe("status", () => {
         appliedAt: "2016-06-03T20:10:12.123Z",
         fileName: "20160509113224-first_migration.js",
         fileHash: "0f295f21f63c66dc78d8dc091ce3c8bab8c56d8b74fb35a0c99f6d9953e37d1a",
+        migrationBlock: undefined
       },
       {
         appliedAt: "2016-06-09T20:10:12.123Z",
         fileName: "20160512091701-second_migration.js",
         fileHash: "18b4d9c95a8678ae3a6dd3ae5b8961737a6c3dd65e3e655a5f5718d97a0bff70",
+        migrationBlock: undefined
       },
       {
         appliedAt: "PENDING",
         fileName: "20160513155321-third_migration.js",
         fileHash: "1f9eb3b5eb70b2fb5b83fa0c660d859082f0bb615e835d29943d26fb0d352022",
+        migrationBlock: undefined
       }
     ]);
   });
@@ -279,16 +288,19 @@ describe("status", () => {
         appliedAt: "2016-06-03T20:10:12.123Z",
         fileName: "20160509113224-first_migration.js",
         fileHash: "0f295f21f63c66dc78d8dc091ce3c8bab8c56d8b74fb35a0c99f6d9953e37d1a",
+        migrationBlock: undefined
       },
       {
         appliedAt: "PENDING",
         fileName: "20160512091701-second_migration.js",
         fileHash: "18b4d9c95a8678ae3a6dd3ae5b8961737a6c3dd65e3e655a5f5718d97a0bff71", // this hash is different
+        migrationBlock: undefined
       },
       {
         appliedAt: "PENDING",
         fileName: "20160513155321-third_migration.js",
         fileHash: "1f9eb3b5eb70b2fb5b83fa0c660d859082f0bb615e835d29943d26fb0d352022",
+        migrationBlock: undefined
       }
     ]);
   });

--- a/test/actions/up.test.js
+++ b/test/actions/up.test.js
@@ -162,7 +162,8 @@ describe("up", () => {
     expect(changelogCollection.insertOne.callCount).to.equal(2);
     expect(changelogCollection.insertOne.getCall(0).args[0]).to.deep.equal({
       appliedAt: new Date("2016-06-09T08:07:00.077Z"),
-      fileName: "20160607173840-first_pending_migration.js"
+      fileName: "20160607173840-first_pending_migration.js",
+      migrationBlock: 1465459620077
     });
     clock.restore();
   });


### PR DESCRIPTION
Hi, here is a possible implementation of `migrate-mongo down` command to enable rollback of several migration scripts of a same migration. When you process to migration you can rollback all migrations scripts from a same migration.

If you have 3 pending migartions and you run `migrate-mongo up`, `migrate-mongo down --block` command will rollback the three migration scripts.

It could be usefull if you want to integrate it.

Thank you :) 

##### Checklist
- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
