### PR TITLE
typo: mistake with async function signature in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ There are 3 options to implement the `up` and `down` functions of your migration
 
 Always make sure the implementation matches the function signature:
 * `function up(db, client) { /* */ }` should return `Promise`
-* `function async up(db, client) { /* */ }` should contain `await` keyword(s) and return `Promise`
+* `async function up(db, client) { /* */ }` should contain `await` keyword(s) and return `Promise`
 * `function up(db, client, next) { /* */ }` should callback `next`
 
 #### Example 1: Return a Promise


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

Fixed small mistake with async function signature in README.md

The line

https://github.com/seppevs/migrate-mongo/blob/4906ff23676ba3b2a9be219be64eb94f440db597/README.md#L132

should be changed into

```markdown
* `async function up(db, client) { /* */ }` should contain `await` keyword(s) and return `Promise`
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] README.md is updated
