### PR TITLE
Fix up/down command console output when logger replaces it.

### DIFF
--- a/bin/migrate-mongo.js
+++ b/bin/migrate-mongo.js
@@ -70,6 +70,8 @@ program
       .then(({db, client}) => migrateMongo.up(db, client))
       .then(migrated => {
         printMigrated(migrated);
+      })
+      .then(() => {
         process.exit(0);
       })
       .catch(err => {
@@ -91,6 +93,8 @@ program
         migrated.forEach(migratedItem => {
           console.log(`MIGRATED DOWN: ${migratedItem}`);
         });
+      })
+      .then(() => {
         process.exit(0);
       })
       .catch(err => {


### PR DESCRIPTION
Hello, this is tiny PR that fixes pretty unique issue.

I am replacing console with logger function, so that when I run `up` or `down` commands, the console output is logged using logger configuration (I am using [log4js](https://www.npmjs.com/package/log4js)).

My config looks like:
```
const mongoConfig = require('./').mongo;
const argv = require('yargs').argv;
const logger = require('log4js').getLogger('migrate-mongo');

// Replace node console with logger for up and down migration commands, so we have a
// log record for these actions.
if (argv._.includes('up') || argv._.includes('down')) {
    console.log = logger.info.bind(logger);
    console.error = logger.error.bind(logger);
}

const config = { 
    mongodb: {
        url: mongoConfig.connection,
        options: {
            useNewUrlParser: true, // removes a deprecation warning when connecting
            useUnifiedTopology: true, // removes a deprecating warning when connecting
        },
    },  
    migrationsDir: 'migrations',
    changelogCollectionName: 'changelog',
};

module.exports = config;
```

This all works fine, I am getting STDOUT output similar to:
```
[2021-05-26T11:17:00.087] [INFO] migrate-mongo - MIGRATED UP: 20210524112904-something_changed.js
```

`Log4js` is configured to use `stdout` and `file` appenders. The problem is that command output goes to standard output, but does not go to the file for unknown reason. Presumably this is related to the fact that process ends synchronously with `console.log` call [in the code](https://github.com/seppevs/migrate-mongo/blob/master/bin/migrate-mongo.js#L71-L73), and internally in node file writing stops too early, just guessing.

So, solution is simple. When I defer `process.exit(0);` to the next tick by moving it in separate `then` in the chain, my issue gets resolved. In fact, you are using the same pattern for `status` command, which I am not interested in logging, but noticed it logs correctly when I remove command condition in the config file.

Please consider accepting this PR 😃 

##### Checklist
- [x] `npm test` passes and has 100% coverage
