### PR TITLE
docs: added '{session}' options to Transactions API samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ module.exports = {
     const session = client.startSession();
     try {
         await session.withTransaction(async () => {
-            await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: true}});
-            await db.collection('albums').updateOne({artist: 'The Doors'}, {$set: {stars: 5}});
+            await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: true}}, {session});
+            await db.collection('albums').updateOne({artist: 'The Doors'}, {$set: {stars: 5}}, {session});
         });
     } finally {
       await session.endSession();
@@ -293,8 +293,8 @@ module.exports = {
     const session = client.startSession();
     try {
         await session.withTransaction(async () => {
-            await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
-            await db.collection('albums').updateOne({artist: 'The Doors'}, {$set: {stars: 0}});
+            await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}}, {session});
+            await db.collection('albums').updateOne({artist: 'The Doors'}, {$set: {stars: 0}}, {session});
         });
     } finally {
       await session.endSession();


### PR DESCRIPTION
Added missing `{session}` options to Transactions API samples: each operation in the function passed to `session.withTransaction` must be associated with the session.

Resolves #382

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] README.md is updated
