### PR TITLE
Extend config for tuning migrations DB records

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,20 @@ module.exports = {
   // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
   changelogCollectionName: "changelog",
 
+  // Field in collection to store migration name
+  nameField: 'fileName',
+
+  // Prefix for migration name
+  namePrefix: '',
+
+  // Whether name should include file extension
+  nameWithoutExtension: false,
+
+  // Field in collection to store migration applied date
+  dateField: 'appliedAt',
+
   // The file extension to create migrations and search for in migration dir 
-  migrationFileExtension: ".js"
+  migrationFileExtension: ".js",
 
   // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determin
   // if the file should be run.  Requires that scripts are coded to be run multiple times.

--- a/lib/actions/down.js
+++ b/lib/actions/down.js
@@ -10,12 +10,17 @@ const hasCallback = require('../utils/has-callback');
 module.exports = async (db, client) => {
   const downgraded = [];
   const statusItems = await status(db);
-  const appliedItems = statusItems.filter(item => item.appliedAt !== "PENDING");
+  const {
+    changelogCollectionName,
+    dateField,
+    nameField,
+  } = await config.read();
+  const appliedItems = statusItems.filter(item => item[dateField] !== "PENDING");
   const lastAppliedItem = _.last(appliedItems);
 
   if (lastAppliedItem) {
     try {
-      const migration = await migrationsDir.loadMigration(lastAppliedItem.fileName);
+      const migration = await migrationsDir.loadMigration(lastAppliedItem.file);
       const down = hasCallback(migration.down) ? promisify(migration.down) : migration.down;
 
       if (hasCallback(migration.down) && fnArgs(migration.down).length < 3) {
@@ -27,14 +32,13 @@ module.exports = async (db, client) => {
 
     } catch (err) {
       throw new Error(
-        `Could not migrate down ${lastAppliedItem.fileName}: ${err.message}`
+        `Could not migrate down ${lastAppliedItem.file}: ${err.message}`
       );
     }
-    const { changelogCollectionName } = await config.read();
     const changelogCollection = db.collection(changelogCollectionName);
     try {
-      await changelogCollection.deleteOne({ fileName: lastAppliedItem.fileName });
-      downgraded.push(lastAppliedItem.fileName);
+      await changelogCollection.deleteOne({ [nameField]: lastAppliedItem[nameField] });
+      downgraded.push(lastAppliedItem.file);
     } catch (err) {
       throw new Error(`Could not update changelog: ${err.message}`);
     }

--- a/lib/actions/status.js
+++ b/lib/actions/status.js
@@ -1,29 +1,42 @@
 const { find } = require("lodash");
 const migrationsDir = require("../env/migrationsDir");
 const config = require("../env/config");
+const getName = require('../utils/name');
 
 module.exports = async db => {
   await migrationsDir.shouldExist();
   await config.shouldExist();
-  const fileNames = await migrationsDir.getFileNames();
+  const configObject = await config.read()
+  const {
+    changelogCollectionName,
+    useFileHash,
+    nameField,
+    dateField,
+  } = configObject;
 
-  const { changelogCollectionName, useFileHash } = await config.read();
   const changelogCollection = db.collection(changelogCollectionName);
+
+  const fileNames = await migrationsDir.getFileNames();
   const changelog = await changelogCollection.find({}).toArray();
 
-
   const useFileHashTest = useFileHash === true;
-  const statusTable = await Promise.all(fileNames.map(async (fileName) => {
+  return Promise.all(fileNames.map(async (fileName) => {
+    const migrationName = getName(configObject, fileName);
+
     let fileHash;
-    let findTest = { fileName };
+    let findTest = { [nameField]: migrationName };
     if (useFileHashTest) {
       fileHash = await migrationsDir.loadFileHash(fileName);
-      findTest = { fileName, fileHash };
+      findTest = { [nameField]: migrationName, fileHash };
     }
-    const itemInLog = find(changelog, findTest);
-    const appliedAt = itemInLog ? itemInLog.appliedAt.toJSON() : "PENDING";
-    return useFileHash ? { fileName, fileHash, appliedAt } : { fileName, appliedAt };
-  }));
 
-  return statusTable;
+    const itemInLog = find(changelog, findTest);
+    const appliedAt = itemInLog ? itemInLog[dateField].toJSON() : "PENDING";
+    return {
+      [nameField]: migrationName,
+      [dateField]: appliedAt,
+      file: fileName,
+      ...(useFileHash && { fileHash }),
+    };
+  }));
 };

--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -1,21 +1,34 @@
+/* eslint no-console: 0 */
 const _ = require("lodash");
 const pEachSeries = require("p-each-series");
 const { promisify } = require("util");
-const fnArgs = require('fn-args');
+const fnArgs = require("fn-args");
 
 const status = require("./status");
 const config = require("../env/config");
 const migrationsDir = require("../env/migrationsDir");
 const hasCallback = require('../utils/has-callback');
+const getName = require('../utils/name');
 
 module.exports = async (db, client) => {
   const statusItems = await status(db);
-  const pendingItems = _.filter(statusItems, { appliedAt: "PENDING" });
+  const configObject = await config.read()
+  const {
+    changelogCollectionName,
+    useFileHash,
+    dateField,
+    nameField,
+  } = configObject;
+
+  const pendingItems = _.filter(statusItems, { [dateField]: "PENDING" });
   const migrated = [];
 
   const migrateItem = async item => {
+    console.info(`Migrating ${item.file}`);
+    const timeTaken = `${item.file} was successfully migrated`;
+    console.time(timeTaken);
     try {
-      const migration = await migrationsDir.loadMigration(item.fileName);
+      const migration = await migrationsDir.loadMigration(item.file);
       const up = hasCallback(migration.up) ? promisify(migration.up) : migration.up;
 
       if (hasCallback(migration.up) && fnArgs(migration.up).length < 3) {
@@ -27,27 +40,36 @@ module.exports = async (db, client) => {
 
     } catch (err) {
       const error = new Error(
-        `Could not migrate up ${item.fileName}: ${err.message}`
+        `Could not migrate up ${item.file}: ${err.message}`
       );
       error.stack = err.stack;
       error.migrated = migrated;
       throw error;
     }
 
-    const { changelogCollectionName, useFileHash } = await config.read();
     const changelogCollection = db.collection(changelogCollectionName);
-
-    const { fileName, fileHash } = item;
+    const { file, fileHash } = item;
+    const migrationName = getName(configObject, file);
     const appliedAt = new Date();
 
     try {
-      await changelogCollection.insertOne(useFileHash === true ? { fileName, fileHash, appliedAt } : { fileName, appliedAt });
+      await changelogCollection.insertOne({
+        [nameField]: migrationName,
+        [dateField]: appliedAt,
+        ...(useFileHash === true && { fileHash }),
+      });
     } catch (err) {
       throw new Error(`Could not update changelog: ${err.message}`);
     }
-    migrated.push(item.fileName);
+    migrated.push(item.file);
+    console.timeEnd(timeTaken);
   };
 
-  await pEachSeries(pendingItems, migrateItem);
+  if (pendingItems.length)
+    await pEachSeries(pendingItems, migrateItem);
+  else
+    console.info('Nothing to migrate');
+
+
   return migrated;
 };

--- a/lib/env/config.js
+++ b/lib/env/config.js
@@ -3,6 +3,8 @@ const path = require("path");
 const { get } = require("lodash");
 
 const DEFAULT_CONFIG_FILE_NAME = "migrate-mongo-config.js";
+const DEFAULT_NAME_FIELD = 'fileName';
+const DEFAULT_DATE_FIELD = 'appliedAt';
 
 let customConfigContent = null;
 
@@ -60,6 +62,14 @@ module.exports = {
       return customConfigContent;
     }
     const configPath = getConfigPath();
-    return Promise.resolve(require(configPath)); // eslint-disable-line
+    const config = await Promise.resolve(require(configPath)); // eslint-disable-line
+
+    if (!config.nameField)
+      config.nameField = DEFAULT_NAME_FIELD;
+
+    if (!config.dateField)
+      config.dateField = DEFAULT_DATE_FIELD;
+
+    return config;
   }
 };

--- a/lib/utils/name.js
+++ b/lib/utils/name.js
@@ -1,0 +1,9 @@
+module.exports = (config, fileName) => {
+  let migrationName = fileName;
+  if (config.namePrefix)
+    migrationName = `${config.namePrefix}${migrationName}`;
+  if (config.nameWithoutExtension)
+    migrationName = migrationName.substring(0, migrationName.lastIndexOf('.')) || migrationName;
+
+  return migrationName
+}

--- a/samples/migrate-mongo-config.js
+++ b/samples/migrate-mongo-config.js
@@ -22,6 +22,18 @@ const config = {
   // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
   changelogCollectionName: "changelog",
 
+  // Field in collection to store migration name
+  nameField: 'fileName',
+
+  // Prefix for migration name
+  namePrefix: '',
+
+  // Whether name should include file extension
+  nameWithoutExtension: false,
+
+  // Field in collection to store migration applied date
+  dateField: 'appliedAt',
+
   // The file extension to create migrations and search for in migration dir 
   migrationFileExtension: ".js",
 

--- a/test/actions/down.test.js
+++ b/test/actions/down.test.js
@@ -17,10 +17,12 @@ describe("down", () => {
     return sinon.stub().returns(
       Promise.resolve([
         {
+          file: "20160609113224-first_migration.js",
           fileName: "20160609113224-first_migration.js",
           appliedAt: new Date()
         },
         {
+          file: "20160609113225-last_migration.js",
           fileName: "20160609113225-last_migration.js",
           appliedAt: new Date()
         }
@@ -31,7 +33,11 @@ describe("down", () => {
   function mockConfig() {
     return {
       shouldExist: sinon.stub().returns(Promise.resolve()),
-      read: sinon.stub().returns({ changelogCollectionName: "changelog" })
+      read: sinon.stub().returns({
+        changelogCollectionName: "changelog",
+        dateField: "appliedAt",
+        nameField: "fileName",
+      })
     };
   }
 

--- a/test/actions/up.test.js
+++ b/test/actions/up.test.js
@@ -19,18 +19,22 @@ describe("up", () => {
     return sinon.stub().returns(
       Promise.resolve([
         {
+          file: "20160605123224-first_applied_migration.js",
           fileName: "20160605123224-first_applied_migration.js",
           appliedAt: new Date()
         },
         {
+          file: "20160606093207-second_applied_migration.js",
           fileName: "20160606093207-second_applied_migration.js",
           appliedAt: new Date()
         },
         {
+          file: "20160607173840-first_pending_migration.js",
           fileName: "20160607173840-first_pending_migration.js",
           appliedAt: "PENDING"
         },
         {
+          file: "20160608060209-second_pending_migration.js",
           fileName: "20160608060209-second_pending_migration.js",
           appliedAt: "PENDING"
         }
@@ -42,7 +46,9 @@ describe("up", () => {
     return {
       shouldExist: sinon.stub().returns(Promise.resolve()),
       read: sinon.stub().returns({
-        changelogCollectionName: "changelog"
+        changelogCollectionName: "changelog",
+        dateField: "appliedAt",
+        nameField: "fileName",
       })
     };
   }

--- a/test/utils/has-callback.test.js
+++ b/test/utils/has-callback.test.js
@@ -5,51 +5,35 @@ const hasCallback = require('../../lib/utils/has-callback');
 describe('has-callback', () => {
 
   it('should return true when last argument is called `callback`', () => {
-    expect(hasCallback((db, callback) => {
-      return callback();
-    })).to.equal(true);
+    expect(hasCallback((db, callback) => callback())).to.equal(true);
   });
 
   it('should return true when last argument is called `callback_`', () => {
-    expect(hasCallback((db, callback_) => {
-      return callback_();
-    })).to.equal(true);
+    expect(hasCallback((db, callback_) => callback_())).to.equal(true);
   });
 
   it('should return true when last argument is called `cb`', () => {
-    expect(hasCallback((db, cb) => {
-      return cb();
-    })).to.equal(true);
+    expect(hasCallback((db, cb) => cb())).to.equal(true);
   });
 
   it('should return true when last argument is called `cb_`', () => {
-    expect(hasCallback((db, cb_) => {
-      return cb_();
-    })).to.equal(true);
+    expect(hasCallback((db, cb_) => cb_())).to.equal(true);
   });
 
   it('should return true when last argument is called `next`', () => {
-    expect(hasCallback((db, next) => {
-      return next();
-    })).to.equal(true);
+    expect(hasCallback((db, next) => next())).to.equal(true);
   });
 
   it('should return true when last argument is called `next_`', () => {
-    expect(hasCallback((db, next_) => {
-      return next_();
-    })).to.equal(true);
+    expect(hasCallback((db, next_) => next_())).to.equal(true);
   });
 
   it('should return true when last argument is called `done`', () => {
-    expect(hasCallback((db, done) => {
-      return done();
-    })).to.equal(true);
+    expect(hasCallback((db, done) => done())).to.equal(true);
   });
 
   it('should return true when last argument is called `done_`', () => {
-    expect(hasCallback((db, done_) => {
-      return done_();
-    })).to.equal(true);
+    expect(hasCallback((db, done_) => done_())).to.equal(true);
   });
 
 });


### PR DESCRIPTION
Extend config to make possible to tune DB records for passed migrations more flexible:

* Add `nameField` property to customize name of record key where migration name stored
* Add `dateField` property to customize name of record key where migration date stored
* Add `namePrefix` and `nameWithoutExtension` properties to make possible to customize migration name
* Add additional logging in `up` method
* Fix lint errors

It is necessary to make possible migration from other similar packages, in my case from [db-migrate](https://github.com/db-migrate/node-db-migrate).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
