### PR TITLE
fix: exit from process after create command is done

### DIFF
--- a/bin/migrate-mongo.js
+++ b/bin/migrate-mongo.js
@@ -56,6 +56,9 @@ program
           console.log(`Created: ${config.migrationsDir}/${fileName}`);
         })
       )
+      .then(() => {
+        process.exit(0);
+      })
       .catch(err => handleError(err));
   });
 


### PR DESCRIPTION
The process was not being finished after the creation of a new migration.

I added the `process.exit(0)` call after the create command is done.

##### Checklist

- [x] `npm test` passes and has 100% coverage
