### PR TITLE
docs: Fix missing command inside README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ module.exports = {
   changelogCollectionName: "changelog",
 
   // The file extension to create migrations and search for in migration dir 
-  migrationFileExtension: ".js"
+  migrationFileExtension: ".js",
 
   // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determin
   // if the file should be run.  Requires that scripts are coded to be run multiple times.


### PR DESCRIPTION
Added missing comma inside README.md

##### Checklist
- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
