### PR TITLE
typo: function async > async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ There are 3 options to implement the `up` and `down` functions of your migration
 
 Always make sure the implementation matches the function signature:
 * `function up(db, client) { /* */ }` should return `Promise`
-* `function async up(db, client) { /* */ }` should contain `await` keyword(s) and return `Promise`
+* `async function up(db, client) { /* */ }` should contain `await` keyword(s) and return `Promise`
 * `function up(db, client, next) { /* */ }` should callback `next`
 
 #### Example 1: Return a Promise


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- N/A `npm test` passes and has 100% coverage
- [x] README.md is updated

It's `async function`, not `function async`!