### PR TITLE
feat (create): add optional timestamp formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ $ migrate-mongo status
 All actions (except ```init```) accept an optional ````-f```` or ````--file```` option to specify a path to a custom config file.
 By default, migrate-mongo will look for a ````migrate-mongo-config.js```` config file in of the current directory.
 
+### Using a custom timestamp format
+If you want to change the timestamp formatting, add a ````timestampFormat```` field to the config file.
+The format ````yyyyMMddHHmmss```` is used by default or if none is provided.
+
 #### Example:
 
 ````bash

--- a/lib/actions/create.js
+++ b/lib/actions/create.js
@@ -3,6 +3,7 @@ const path = require("path");
 const date = require("../utils/date");
 const migrationsDir = require("../env/migrationsDir");
 const config = require("../env/config");
+const _ = require("lodash");
 
 module.exports = async description => {
   if (!description) {
@@ -21,7 +22,15 @@ module.exports = async description => {
     source = path.join(__dirname, `../../samples/${configContent.moduleSystem}/migration.js`);
   }
 
-  const filename = `${date.nowAsString()}-${description
+  let formatting;
+  try {
+    const configContent = await config.read();
+    formatting = _.get(configContent, "timestampFormat");
+  } catch (err) {
+    // config file could not be read, assume default formatting
+  }
+
+  const filename = `${date.nowAsString(formatting)}-${description
     .split(" ")
     .join("_")}${migrationExtension}`;
   const destination = path.join(migrationsDirPath, filename);

--- a/lib/utils/date.js
+++ b/lib/utils/date.js
@@ -13,7 +13,7 @@ const now = (dateString = Date.now()) => {
   );
 };
 
-const nowAsString = () => format(now(), "yyyyMMddHHmmss");
+const nowAsString = (formatting = "yyyyMMddHHmmss") => format(now(), formatting);
 
 module.exports = {
   now,

--- a/test/actions/create.test.js
+++ b/test/actions/create.test.js
@@ -91,6 +91,35 @@ describe("create", () => {
     clock.restore();
   });
 
+  it("should create a new migration file and yield the filename with custom formatting", async () => {
+    const configWithTimestamp = {
+      read: sinon.stub().returns(Promise.resolve({
+        moduleSystem: 'commonjs',
+        timestampFormat: 'yyyy-MM-dd-HH:mm'
+      }))
+    };
+
+    const createWithTimestamp = proxyquire("../../lib/actions/create", {
+      "../env/migrationsDir": migrationsDir,
+      "../env/config": configWithTimestamp,
+      "fs-extra": fs
+    });
+
+    const clock = sinon.useFakeTimers(
+      new Date("2016-06-09T08:07:00.077Z").getTime()
+    );
+    const filename = await createWithTimestamp("my_description");
+    expect(fs.copy.called).to.equal(true);
+    expect(fs.copy.getCall(0).args[0]).to.equal(
+      path.join(__dirname, "../../samples/commonjs/migration.js")
+    );
+    expect(fs.copy.getCall(0).args[1]).to.equal(
+      path.join(process.cwd(), "migrations", "2016-06-09-08:07-my_description.js")
+    );
+    expect(filename).to.equal("2016-06-09-08:07-my_description.js");
+    clock.restore();
+  });
+
   it("should create a new migration file and yield the filename with custom extension", async () => {
     const clock = sinon.useFakeTimers(
       new Date("2016-06-09T08:07:00.077Z").getTime()


### PR DESCRIPTION
Added some optional timestamp formatting options. 

Reasoning behind this PR is to integrate this package in a project with other formatting in it's older migrations folder. I did not add the key in the default config file since it's not an important feature.

Thanks Seb for creating and maintaining this package! Groet, Hidde

##### Checklist
- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
