### PR TITLE
Add -md command line param to set migrationsDir property

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,17 @@ $ migrate-mongo status -f '~/configs/albums-migrations.js'
 └─────────────────────────────────────────┴────────────┘
 
 ````
+### Using a custom migrations directory
+All actions (except ```init```) accept an optional ````-md```` or ````--migrations-dir```` option to specify a path to a custom migrations directory. This will override the migrationsDir property in the config file.
+
+By default, migrate-mongo will look for a ````migrations```` directory in the current directory.
+
+#### Example:
+
+````bash
+$ migrate-mongo create blacklist_the_doors -md ~/migrations/albums
+Created: ~/migrations/albums/20160608155949-blacklist_the_doors.js
+````
 
 ### Using npm packages in your migration scripts
 You can use use Node.js modules (or require other modules) in your migration scripts.

--- a/bin/migrate-mongo.js
+++ b/bin/migrate-mongo.js
@@ -49,6 +49,7 @@ program
   .command("create [description]")
   .description("create a new database migration with the provided description")
   .option("-f --file <file>", "use a custom config file")
+  .option("-md --migrationsDir <migrationsDir>", "use a custom migrations directory")
   .action((description, options) => {
     global.options = options;
     migrateMongo
@@ -68,6 +69,7 @@ program
   .command("up")
   .description("run all pending database migrations")
   .option("-f --file <file>", "use a custom config file")
+  .option("-md --migrationsDir <migrationsDir>", "use a custom migrations directory")
   .action(options => {
     global.options = options;
     migrateMongo.database
@@ -87,6 +89,7 @@ program
   .command("down")
   .description("undo the last applied database migration")
   .option("-f --file <file>", "use a custom config file")
+  .option("-md --migrationsDir <migrationsDir>", "use a custom migrations directory")
   .action(options => {
     global.options = options;
     migrateMongo.database
@@ -107,6 +110,7 @@ program
   .command("status")
   .description("print the changelog of the database")
   .option("-f --file <file>", "use a custom config file")
+  .option("-md --migrationsDir <migrationsDir>", "use a custom migrations directory")
   .action(options => {
     global.options = options;
     migrateMongo.database

--- a/lib/env/config.js
+++ b/lib/env/config.js
@@ -20,6 +20,24 @@ function getConfigPath() {
   return path.join(process.cwd(), fileOptionValue);
 }
 
+function setMigrationsDirCommandLineParamInConfig(config) {
+  const getMigrationDirCommandLineParameter = () => {
+    const args = process.argv.slice(2);
+    const mdIndex = args.indexOf('-md');
+    return mdIndex !== -1 ? args[mdIndex + 1] : null;
+  };
+
+  // deep copy of config
+  const rtn = JSON.parse(JSON.stringify(config));
+
+  const md = getMigrationDirCommandLineParameter();
+  if (md) {
+    rtn.migrationsDir = md;
+  }
+
+  return rtn;
+}
+
 module.exports = {
   DEFAULT_CONFIG_FILE_NAME,
 
@@ -63,7 +81,11 @@ module.exports = {
     }
     const configPath = getConfigPath();
     try {
-      return await Promise.resolve(moduleLoader.require(configPath));
+        let config = moduleLoader.require(configPath);
+
+        config = setMigrationsDirCommandLineParamInConfig(config);
+
+        return config;
     } catch (e) {
       if (e.code === 'ERR_REQUIRE_ESM') {
         const loadedImport = await moduleLoader.import(url.pathToFileURL(configPath));

--- a/test/env/config.test.js
+++ b/test/env/config.test.js
@@ -142,5 +142,33 @@ describe("config", () => {
       await config.read();
       expect(moduleLoader.import.called).to.equal(true);
     });
+
+    it("should return an object with the migrationsDir property set if the command line parameter is set", async () => {
+
+        const expected = { migrationsDir: "some/other/dir" };
+        moduleLoader.require = sinon.stub().returns({migrationsDir: "the/initial/dir"});
+
+        // set process.argv to simulate the -md command line parameter
+        const originalArgv = process.argv;
+        process.argv = [...originalArgv, "-md", expected.migrationsDir];
+
+        const actual = await config.read();
+        expect(actual).to.deep.equal(expected);
+    });
+
+    it("should use the config file migrationsDir property if the command line parameter is not set", async () => {
+
+      const origConfig = { migrationsDir: "the/orig/path" };
+      moduleLoader.require = sinon.stub().returns(origConfig);
+
+        // set process.argv to simulate the -md command line parameter
+        const originalArgv = process.argv;
+        // originalArgv, filter the -md command line parameter and its value
+        process.argv = originalArgv.filter(arg => arg !== "-md" && arg !== origConfig.migrationsDir);
+
+      const actual = await config.read();
+      expect(actual).to.deep.equal(origConfig);
+    });
+
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `npm test` passes and has 100% coverage
- [ x] README.md is updated

Adds a command line parameter to set the `migrationsDir` property. 

Imagine a program which generates two types of migration scripts, 1) for schemas, and also 2) to insert test data. Initially, I was putting the two types in a single directory, but I ran into a problem in that the schemas need to be applied before the insert-test-datas, otherwise you may lose data. My solution was to move the logic of schemas-before-test-data to the program, by creating a directory for each type of migration, and then calling the schemas to be up'd first, and then the test-datas. 

However, the directory which migration scripts are read from/written to is determined by the `migrationDirs` property in the `migrate-mongo-config.js` file. So to output to/read from the individual type directories, I would need to edit this file to refer to one or the other before calling migrate-mongo. It was easier modify migrate-mongo to accept a command line parameter, than to deal with programatically editing via awk/sed, the config file.
