### PR TITLE
Fix "No `url` defined in config file" when using ESM

### DIFF
--- a/lib/env/config.js
+++ b/lib/env/config.js
@@ -63,13 +63,19 @@ module.exports = {
     }
     const configPath = getConfigPath();
     try {
-      return await Promise.resolve(moduleLoader.require(configPath));
+      const result = await moduleLoader.require(configPath);
+      return getModuleExports(result);
     } catch (e) {
       if (e.code === 'ERR_REQUIRE_ESM') {
         const loadedImport = await moduleLoader.import(url.pathToFileURL(configPath));
-        return loadedImport.default
+        return getModuleExports(loadedImport);
       }
       throw e;
     }
   }
 };
+
+function getModuleExports(module) {
+  // If ESM module format need to return default export
+  return module.default ? module.default : module;
+}

--- a/lib/env/config.js
+++ b/lib/env/config.js
@@ -20,6 +20,11 @@ function getConfigPath() {
   return path.join(process.cwd(), fileOptionValue);
 }
 
+function getModuleExports(module) {
+  // If ESM module format need to return default export
+  return module.default ? module.default : module;
+}
+
 module.exports = {
   DEFAULT_CONFIG_FILE_NAME,
 
@@ -74,8 +79,3 @@ module.exports = {
     }
   }
 };
-
-function getModuleExports(module) {
-  // If ESM module format need to return default export
-  return module.default ? module.default : module;
-}

--- a/test/env/config.test.js
+++ b/test/env/config.test.js
@@ -142,5 +142,35 @@ describe("config", () => {
       await config.read();
       expect(moduleLoader.import.called).to.equal(true);
     });
+
+    it("should handle ESM modules with default export", async () => {
+      const expectedConfig = {
+        mongodb: {
+          url: 'mongodb://localhost:27017',
+          databaseName: 'test'
+        }
+      };
+      
+      moduleLoader.require = sinon.stub().resolves({
+        default: expectedConfig
+      });
+      
+      const actual = await config.read();
+      expect(actual).to.deep.equal(expectedConfig);
+    });
+
+    it("should handle regular CommonJS modules", async () => {
+      const expectedConfig = {
+        mongodb: {
+          url: 'mongodb://localhost:27017',
+          databaseName: 'test'
+        }
+      };
+      
+      moduleLoader.require = sinon.stub().resolves(expectedConfig);
+      
+      const actual = await config.read();
+      expect(actual).to.deep.equal(expectedConfig);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->

I recently ran into an issue where I could now longer migrate because I was getting the error: "ERROR: No `url` defined in config file! Error: No `url` defined in config file!".

The issue is that the code for handling importing the config file when it is ESM assumes that node will throw an error when you try to require an ESM file.  That error was no longer being thrown and the returned module was all nested under `default`.  As result, it couldn't find the `url`.

This PR, correctly handles this case.  

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes and has 100% coverage
