### PR TITLE
fallback to esm loading when top level await is causing issues

### DIFF
--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -102,7 +102,7 @@ module.exports = {
       const result = moduleLoader.require(migrationPath);
       return getModuleExports(result);
     } catch (e) {
-      if (e.code === 'ERR_REQUIRE_ESM') {
+      if (e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_REQUIRE_ASYNC_MODULE') {
         const loadedImport = moduleLoader.import(url.pathToFileURL(migrationPath));
         return getModuleExports(loadedImport);
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests
-->
When trying to use an ESM dependency having a top level await, the `require` fails, but with an `import` it would work. This quick fix is now just adding another error to the list, but maybe it would even be an idea to fall back to the `import` for every error, or make this dependent on the `moduleSystem` from the config.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes 
