### PR TITLE
Properly handle `ERR_REQUIRE_ASYNC_MODULE`

### DIFF
--- a/lib/env/config.js
+++ b/lib/env/config.js
@@ -71,7 +71,7 @@ module.exports = {
       const result = await moduleLoader.require(configPath);
       return getModuleExports(result);
     } catch (e) {
-      if (e.code === 'ERR_REQUIRE_ESM') {
+      if (e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_REQUIRE_ASYNC_MODULE') {
         const loadedImport = await moduleLoader.import(url.pathToFileURL(configPath));
         return getModuleExports(loadedImport);
       }

--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -102,7 +102,7 @@ module.exports = {
       const result = moduleLoader.require(migrationPath);
       return getModuleExports(result);
     } catch (e) {
-      if (e.code === 'ERR_REQUIRE_ESM') {
+      if (e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_REQUIRE_ASYNC_MODULE') {
         const loadedImport = moduleLoader.import(url.pathToFileURL(migrationPath));
         return getModuleExports(loadedImport);
       }

--- a/test/env/config.test.js
+++ b/test/env/config.test.js
@@ -143,6 +143,15 @@ describe("config", () => {
       expect(moduleLoader.import.called).to.equal(true);
     });
 
+    it("should fall back to using 'import' if Node requires the use of ESM (top-level await)", async () => {
+      const error = new Error('ESM required');
+      error.code = 'ERR_REQUIRE_ASYNC_MODULE';
+      moduleLoader.require = sinon.stub().throws(error);
+      moduleLoader.import.returns({});
+      await config.read();
+      expect(moduleLoader.import.called).to.equal(true);
+    });
+
     it("should handle ESM modules with default export", async () => {
       const expectedConfig = {
         mongodb: {

--- a/test/env/migrationsDir.test.js
+++ b/test/env/migrationsDir.test.js
@@ -202,6 +202,15 @@ describe("migrationsDir", () => {
       await migrationsDir.loadMigration("someFile.js");
       expect(moduleLoader.import.called).to.equal(true);
     });
+
+    it("should fall back to using 'import' if Node requires the use of ESM (top-level await)", async () => {
+      const error = new Error('ESM required');
+      error.code = 'ERR_REQUIRE_ASYNC_MODULE';
+      moduleLoader.require = sinon.stub().throws(error);
+      moduleLoader.import = sinon.stub().returns({ up: sinon.stub(), down: sinon.stub() });
+      await migrationsDir.loadMigration("someFile.js");
+      expect(moduleLoader.import.called).to.equal(true);
+    });
   });
 
   describe("resolveMigrationFileExtension()", () => {


### PR DESCRIPTION
Recent Node.js versions throw `ERR_REQUIRE_ASYNC_MODULE` instead of `ERR_REQUIRE_ESM` if `require()` is used to import a module with top- level await.

Minimal reproduction: https://github.com/mxxk-examples/migrate-mongo-async-esm-issue

Fixes #469 (by making a superset of the changes in that PR).

Potentially related to #458.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes and has 100% coverage
